### PR TITLE
Add MatrixStateCast and enhance Matrix validation

### DIFF
--- a/resources/views/components/matrix-choice.blade.php
+++ b/resources/views/components/matrix-choice.blade.php
@@ -39,7 +39,7 @@
                             <input
                                 {{ $attributes }}
                                 @if($isDisabled || ($isOptionDisabled($columnKey,'') && $isOptionDisabled($rowKey,''))) disabled @endif
-                                wire:key="{{ $id }}.{{ $rowKey }}"
+                                wire:key="{{ $id }}.{{ $rowKey }}.{{ $columnKey }}"
                                 wire:loading.attr="disabled"
                                 {{ $applyStateBindingModifiers('wire:model') }}="{{ $supStatPath }}"
                                 value="{{ $columnKey }}"

--- a/src/Components/Matrix.php
+++ b/src/Components/Matrix.php
@@ -10,6 +10,7 @@ use LaraZeus\MatrixChoice\MatrixStateCast;
 
 class Matrix extends CheckboxList
 {
+    /** @phpstan-ignore-next-line  */
     protected string $view = 'zeus-matrix-choice::components.matrix-choice';
 
     protected array | Closure $columnData = [];

--- a/src/Components/Matrix.php
+++ b/src/Components/Matrix.php
@@ -4,6 +4,9 @@ namespace LaraZeus\MatrixChoice\Components;
 
 use Closure;
 use Filament\Forms\Components\CheckboxList;
+use Illuminate\Validation\Rules\Enum;
+use Illuminate\Validation\Rules\In;
+use LaraZeus\MatrixChoice\MatrixStateCast;
 
 class Matrix extends CheckboxList
 {
@@ -21,20 +24,34 @@ class Matrix extends CheckboxList
     {
         parent::setUp();
 
-        $this->rules([
-            function () {
-                return function (string $attribute, mixed $value, Closure $fail) {
+        $this
+            ->stateCast(app(MatrixStateCast::class))
+            ->rules([
+                fn () => function (string $attribute, mixed $value, Closure $fail) {
+                    $pillColor = $this->getPilColor();
                     if ($this->rowSelectRequired && (blank($value) || count($this->getRowData()) !== count($value))) {
                         $fail(__('required a selection for each row'));
                     }
-                    foreach ($value as $val) {
-                        if ($this->rowSelectRequired && is_array($val) && blank(array_filter($val))) {
+
+                    foreach ($value as $rowData => $columnData) {
+                        if ($this->rowSelectRequired && is_array($columnData) && blank(array_filter($columnData))) {
                             $fail(__('required a selection for each row'));
                         }
+
+                        if (! in_array($rowData, array_keys($this->getRowData()))) {
+                            $fail(__('the selected :attribute is invalid'));
+                        }
+
+                        if ($pillColor === 'checkbox' && count(array_diff_key($columnData, $this->getColumnData()))) {
+                            $fail(__('the selected :attribute is invalid'));
+                        }
+
+                        if ($pillColor === 'radio' && ! in_array($columnData, array_keys($this->getColumnData()))) {
+                            $fail(__('the selected :attribute is invalid'));
+                        }
                     }
-                };
-            },
-        ]);
+                },
+            ]);
     }
 
     public function columnData(array $data): static
@@ -85,5 +102,10 @@ class Matrix extends CheckboxList
         $this->rowSelectRequired = $rowSelectRequired;
 
         return $this;
+    }
+
+    public function getInValidationRule(): In | Enum | null
+    {
+        return null;
     }
 }

--- a/src/MatrixStateCast.php
+++ b/src/MatrixStateCast.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace LaraZeus\MatrixChoice;
+
+use BackedEnum;
+use Filament\Schemas\Components\StateCasts\OptionsArrayStateCast;
+use Illuminate\Support\Arr;
+
+class MatrixStateCast extends OptionsArrayStateCast
+{
+    public function get(mixed $state): array
+    {
+        if (blank($state)) {
+            return [];
+        }
+
+        if (! is_array($state)) {
+            $state = json_decode($state, associative: true);
+        }
+        $keys = array_keys(Arr::wrap($state));
+
+        return array_reduce(
+            Arr::wrap($state),
+            function (array $carry, $stateItem) use (&$keys): array {
+                if (blank($stateItem)) {
+                    return $carry;
+                }
+                $key = array_shift($keys);
+
+                if ($stateItem instanceof BackedEnum) {
+                    $stateItem = $stateItem->value;
+                }
+
+                if (
+                    is_int($stateItem)
+                    || (
+                        is_string($stateItem)
+                        && ctype_digit($stateItem)
+                        && (($stateItem === '0') || (! str($stateItem)->startsWith('0')))
+                    )
+                ) {
+                    $max = (string) PHP_INT_MAX;
+
+                    if (
+                        (strlen($stateItem) > strlen($max)) ||
+                        ((strlen($stateItem) === strlen($max)) && (strcmp($stateItem, $max) > 0))
+                    ) {
+                        $carry[] = strval($stateItem);
+                    } else {
+                        $carry[] = intval($stateItem);
+                    }
+                } else {
+                    if (is_array($stateItem)) {
+                        $carry[$key] = $stateItem;
+                    } else {
+                        $carry[] = strval($stateItem);
+                    }
+                }
+
+                return $carry;
+            },
+            initial: [],
+        );
+    }
+
+    public function set(mixed $state): array
+    {
+        if (blank($state)) {
+            return [];
+        }
+
+        if (! is_array($state)) {
+            $state = json_decode($state, associative: true);
+        }
+
+        return array_reduce(
+            Arr::wrap($state),
+            function (array $carry, $stateItem): array {
+                if (blank($stateItem)) {
+                    return $carry;
+                }
+
+                if ($stateItem instanceof BackedEnum) {
+                    $stateItem = $stateItem->value;
+                }
+
+                $carry[] = strval($stateItem);
+
+                return $carry;
+            },
+            initial: [],
+        );
+    }
+}

--- a/src/MatrixStateCast.php
+++ b/src/MatrixStateCast.php
@@ -73,18 +73,26 @@ class MatrixStateCast extends OptionsArrayStateCast
             $state = json_decode($state, associative: true);
         }
 
+        $keys = array_keys(Arr::wrap($state));
+
         return array_reduce(
             Arr::wrap($state),
-            function (array $carry, $stateItem): array {
+            function (array $carry, $stateItem) use (&$keys): array {
                 if (blank($stateItem)) {
                     return $carry;
                 }
+
+                $key = array_shift($keys);
 
                 if ($stateItem instanceof BackedEnum) {
                     $stateItem = $stateItem->value;
                 }
 
-                $carry[] = strval($stateItem);
+                if (is_array($stateItem)) {
+                    $carry[$key] = $stateItem;
+                } else {
+                    $carry[] = strval($stateItem);
+                }
 
                 return $carry;
             },


### PR DESCRIPTION
Introduces the MatrixStateCast class for custom state casting in matrix components. Updates Matrix.php to use the new state cast and improves validation logic for row and column selections, supporting both checkbox and radio modes.


Fixes #35 